### PR TITLE
Changed .deliver to deliver_now for rails 5 compatibility.

### DIFF
--- a/lib/capistrano/notifier/mail.rb
+++ b/lib/capistrano/notifier/mail.rb
@@ -57,7 +57,7 @@ class Capistrano::Notifier::Mail < Capistrano::Notifier::Base
 
   def perform_with_action_mailer(notifier = Capistrano::Notifier::Mailer)
     notifier.smtp_settings = smtp_settings
-    notifier.notice(text, from, subject, to, notify_method, format).deliver
+    notifier.notice(text, from, subject, to, notify_method, format).deliver_now
   end
 
   def email_template


### PR DESCRIPTION
This should remove the depreciation warning when using this gem.

`DEPRECATION WARNING: '#deliver' is deprecated and will be removed in Rails 5. Use '#deliver_now' to deliver immediately or '#deliver_later' to deliver through Active Job. (called from perform_with_action_mailer at /Users/David/.rvm/gems/ruby-2.2.3/bundler/gems/capistrano-notifier-3f8732ccc6be/lib/capistrano/notifier/mail.rb:60)`
